### PR TITLE
fix typos in LightweightObserver class comments

### DIFF
--- a/LightweightObserver/LoDiceAdderPresenter.class.st
+++ b/LightweightObserver/LoDiceAdderPresenter.class.st
@@ -1,5 +1,5 @@
 "
-I am a spect presenter for DiceAdder.
+I am a spec presenter for DiceAdder.
 I display the faces up for all Dice.
 I display the total of all faces  up.
 I allow rolling all dice or make individual dice roll.

--- a/LightweightObserver/LoSubject.class.st
+++ b/LightweightObserver/LoSubject.class.st
@@ -1,5 +1,5 @@
 "
-I am a subject that can have many observers. I automatically generate events  for IV assignments. Observers can subscribe to those events using mehtods :
+I am a subject that can have many observers. I automatically generate events  for IV assignments. Observers can subscribe to those events using methods :
 - afterChangeOf: ivName do: aBlock
 aBlock is valued after executing a method that assigns a new value to the referenced IV.
 aBlock can have 0 or 1 argument which is the last value of the changed IV.
@@ -9,7 +9,7 @@ aBlock is valued after executing a method that performs assignments to one or mo
 aBlock can have 0 or 1 argument which is the event materializing the change.
 Changed IVs and their last values are stored in the event (see LoIvChangeEvent).
  
-Each of the above methods ansewers an object that is the observer. It can be used to unsbscribe from the subject and stop observing.
+Each of the above methods answers an object that is the observer. It can be used to unsubscribe from the subject and stop observing.
 
     Instance Variables
 	dispatcher:		<LoEventDispatcher>

--- a/LightweightObserver/LoSubjectBasicMethodChangeForbiddenError.class.st
+++ b/LightweightObserver/LoSubjectBasicMethodChangeForbiddenError.class.st
@@ -1,5 +1,5 @@
 "
-I am an error signaled upon an attempt to modify or remove  a subject basic method
+I am an error signaled upon an attempt to modify or remove a subject basic method
 "
 Class {
 	#name : #LoSubjectBasicMethodChangeForbiddenError,


### PR DESCRIPTION
Minor typo fixes in `LoDiceAdderPresenter`, `LoSubject`, and `LoSubjectBasicMethodChangeForbiddenError` class comments